### PR TITLE
Fix ODYM_RECC_Main.py

### DIFF
--- a/ODYM_RECC_Main.py
+++ b/ODYM_RECC_Main.py
@@ -656,7 +656,7 @@ if ScriptConfig['Include_REStrategy_FabScrapDiversion'] == 'False':
 ParameterDict['4_PY_EoL_RecoveryRate'].Values = np.einsum('gmwW,r->grmwW',ParameterDict['4_PY_EoL_RecoveryRate'].Values[:,0,:,:,:],np.ones((Nr)))
 
 # 6) Energy carrier split of vehicles, replicate fixed values for all regions and age-cohorts etc.
-ParameterDict['3_SHA_EnergyCarrierSplit_Vehicles'].Values = np.einsum('pn,crVS->cprVnS',ParameterDict['3_SHA_EnergyCarrierSplit_Vehicles'].Values[115,:,0,3,:,SSP1index].copy(),np.ones((Nc,Nr,NV,NS)))
+ParameterDict['3_SHA_EnergyCarrierSplit_Vehicles'].Values = np.einsum('pn,crVS->cprVnS',ParameterDict['3_SHA_EnergyCarrierSplit_Vehicles'].Values[115,:,0,Service_Drivg,:,SSP1index].copy(),np.ones((Nc,Nr,NV,NS)))
 
 # 7) RE strategy potentials for individual countries are replicated from global average:
 ParameterDict['6_PR_ReUse_Bld'].Values                      = np.einsum('mB,r->mBr',ParameterDict['6_PR_ReUse_Bld'].Values[:,:,0],np.ones(Nr))


### PR DESCRIPTION
Service "driving" was called by its old index 3.
Most recent Config file has additional "lighting" as service, pushing driving to index 4. The index choice is replaced by its index read from the classification and not set manually anymore.